### PR TITLE
Embedded the pdf, now we can see the pdf of each bill without leaving our website. 

### DIFF
--- a/OpenGovCore/urls.py
+++ b/OpenGovCore/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('debates/type/<type>/',DebatesByType.as_view(),name='debates_type'),
     path('debates/house/<house>/',DebatesByHouse.as_view(),name='debates_house'),
     path('bills/',A_Bill.as_view(),name='all_bills'),
+    path('bill/<pk>/', BillDetails.as_view(), name = 'bill_detail'),
     path('bills/year/<year>/',BillsByYear.as_view(),name='bills_year'),
     path('bills/type/<type>/',BillsByType.as_view(),name='bills_type'),
     path('bills/status/<status>/',BillsByStatus.as_view(),name='bills_status'),

--- a/OpenGovCore/views.py
+++ b/OpenGovCore/views.py
@@ -454,3 +454,10 @@ class BillsByStatus(View):
         except EmptyPage:
             data = paginator.page(paginator.num_pages)
         return render(request,self.template_name, {'bills':data,'check':status,'urlvar':'status'})
+
+class BillDetails(View):
+    template_name = "bill_detail.html"
+
+    def get(self, request, pk):
+        bill_data = Bills.objects.get(pk = pk)
+        return render(request, self.template_name, {'bill' : bill_data})

--- a/templates/bill_detail.html
+++ b/templates/bill_detail.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+{% extends "basic_layout.html" %}
+    {% block title %}
+        Bills
+    {% endblock %}
+
+    {% block body_block %}
+    <br>
+    <h2>{{ bill.title }}</h2>
+            <tbody>
+                <tr>
+                    <iframe src= {{ bill.source }} style="width:1000px; height:500px;" frameborder="0"></iframe>
+                    <br>
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <h5 class="mt-4 mb-3">Bill Details</h5>
+                            <table class="table user-view-table m-0">
+                                <tbody>
+                                    <tr>
+                                        <td>Type :</td>
+                                        <td>{{ bill.type }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Status :</td>
+                                        <td>{{ bill.status }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Introducer :</td>
+                                        <td>{{ bill.candidate_id.name }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Date of Introduction :</td>
+                                        <td>{{ bill.date_of_introduction }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Term ID :</td>
+                                        <td>{{ bill.term_id }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Central Legislatures :</td>
+                                        <td>{{ bill.central_legislature_id }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <hr class="border-light m-0">
+                    </div>
+            </tbody>
+    {% endblock %}
+
+    

--- a/templates/bills.html
+++ b/templates/bills.html
@@ -51,10 +51,11 @@
                       <th scope="col">Status</th>
                   </tr>
               </thead>
+
               <tbody>
                   {% for i in bills %}
                   <tr>
-                      <td>{{ i.title }} <a href="{{ i.source }}" target='_blank'><i class="fa fa-external-link-square" aria-hidden="true"></i></a></td>
+                      <td><a href="{% url 'bill_detail' i.pk %}">{{ i.title }}</a></td>
                       <td>{{ i.type }}</td>
                       <td>{{ i.date_of_introduction }}</td>
                       <td>{{ i.status }}</td>


### PR DESCRIPTION
fixes #82 

Embedded the pdf, now we can see the pdf of each bill without leaving our website.

Added new template called bill_detail.html which would take you to a new webpage when you clicked on the bill title on the page that lists all bills.